### PR TITLE
Routes should go at the end

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
-Spree::Core::Engine.routes.prepend do
+Spree::Core::Engine.routes.append do
   namespace :admin do
     resources :subscriptions do
       resource :customer, :controller => "subscriptions/customer_details"


### PR DESCRIPTION
Otherwise admin/products/search path is caught by this bug: https://github.com/spree/spree_related_products/issues/58
