### PR TITLE
Use symbols for payment decorator states

### DIFF
--- a/app/models/spree/payment_decorator.rb
+++ b/app/models/spree/payment_decorator.rb
@@ -1,7 +1,7 @@
 module Spree
   Payment.class_eval do
-    state_machine :initial => 'checkout' do
-      after_transition :to => 'completed', :do => :create_subscriptions!
+    state_machine :initial => :checkout do
+      after_transition :to => :completed, :do => :create_subscriptions!
     end
 
     def create_subscriptions!


### PR DESCRIPTION
By re-defining the state machine like this, the state_machine gem will complain because 'checkout' != :checkout and 'completed' != :completed.

See this thread on the mailing list: https://groups.google.com/forum/#!topic/spree-user/BEbfbrAWOLM
