### PR TITLE
Allow Issue to get deleted Magazine and Mag_Issue

### DIFF
--- a/app/models/spree/issue.rb
+++ b/app/models/spree/issue.rb
@@ -21,4 +21,15 @@ class Spree::Issue < ActiveRecord::Base
   def shipped?
     !shipped_at.nil?
   end
+    
+  def magazine
+    # override getter method to include deleted products, as per https://github.com/radar/paranoia
+    Spree::Product.unscoped { super }
+  end
+  
+  def magazine_issue
+    # override getter method to include deleted products, as per https://github.com/radar/paranoia
+    Spree::Product.unscoped { super }
+  end
+
 end


### PR DESCRIPTION
The `paranoia` gem adds a `default_scope` to `Spree::Product` that hides all deleted Products.

However, I can imagine that a site admin might want to see all the issues in a subscription even if those products are old and have been deleted.

This syntax allows the getter methods to use the unscoped versions of the Product model.

Note that this applies to `Issue.first.magazine` but does _not_ apply to `Issue.includes(:magazine).first.magazine` -- this is a known and outstanding issue in the `paranoia` gem.
