### PR TITLE
Shortcut for ShippedIssue#magazine_issue

### DIFF
--- a/app/models/spree/shipped_issue.rb
+++ b/app/models/spree/shipped_issue.rb
@@ -1,6 +1,7 @@
 class Spree::ShippedIssue < ActiveRecord::Base
   belongs_to :issue, :autosave => true
   belongs_to :subscription, :autosave => true
+  has_one :magazine_issue, through: :issue
 
   #attr_accessible :subscription, :issue
 end


### PR DESCRIPTION
Here we can write `ShippedIssue.magazine_issue` rather than always needing to write `ShippedIssue.issue.magazine_issue`, similar to the way that Spree uses  `LineItem.product` as a shortcut for `LineItem.variant.product`.
