### PR TITLE
Don't throw exception when product is soft-deleted

### DIFF
--- a/app/controllers/spree/admin/products/issues_controller.rb
+++ b/app/controllers/spree/admin/products/issues_controller.rb
@@ -63,7 +63,7 @@ module Spree
         private
 
         def load_magazine
-          @magazine = Product.find_by_slug(params[:magazine_id])
+          @magazine = Product.with_deleted.find_by_slug(params[:magazine_id])
           @product = @magazine # useful to display product_tab menu
         end
 


### PR DESCRIPTION
A long-running store may have Issue objects attached to Products which have been soft-deleted and removed from sale. For bookkeeping reasons, account history, and the like, we want to still be able to allow Issues to know which Magazine they're issues of. This is accomplished simply by using the `with_deleted` scope.
