### PR TITLE
Fix shipped?(issue) method

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -66,7 +66,7 @@ class Spree::Subscription < ActiveRecord::Base
   end
 
   def shipped?(issue)
-    !shipped_issues.where(:id => issue.id).empty?
+    shipped_issues.where(issue: issue).present?
   end
 
   def allow_cancel?


### PR DESCRIPTION
This corrects what appears to have been a bug in the `Subscription.shipped?(issue)` method, where the logic had been:

```
!shipped_issues.where(:id => issue.id).empty?
```

which seemed off to me -- the `:id` of a shipped_issue would be the shipped_issue's _own_ id, not the issue_id. So I changed that to

```
!shipped_issues.where(issue: issue).empty?
```

which I think is the original intention.

Note that I also suggested changing `!empty?` to `present?` for simplicity:

```
shipped_issues.where(issue: issue).present?
```
