### PR TITLE
updating syntax for issue#new in admin view

### DIFF
--- a/app/views/spree/admin/products/issues/index.html.erb
+++ b/app/views/spree/admin/products/issues/index.html.erb
@@ -2,14 +2,11 @@
 
 <%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Issues' } %>
 
-<div class="toolbar" data-hook="toolbar">
-  <ul class="actions">
-    <li id="new_issue_link">
-    <%= button_link_to t(:new_issue), new_admin_magazine_issue_url(@magazine), { :icon => 'add', :id => 'admin_new_issue' } %>
-    </li>
-  </ul>
-  <br class="clear" />
-</div>
+<% content_for :page_actions do %>
+  <li id="new_product_link">
+    <%= button_link_to Spree.t(:new_issue), new_admin_magazine_issue_url(@magazine), { :icon => 'add', :id => 'admin_new_issue' } %>
+  </li>
+<% end if can?(:create, Spree::Issue) %>
 
 <h1><%= t("listing_issues") %></h1>
 


### PR DESCRIPTION
This brings the `New Issue` button up to the Spree 2.x admin view conventions.
