### PR TITLE
Cleaner syntax to get Subscriptions from Issues

### DIFF
--- a/app/controllers/spree/admin/products/issues_controller.rb
+++ b/app/controllers/spree/admin/products/issues_controller.rb
@@ -8,7 +8,7 @@ module Spree
 
         def show
           if @issue.shipped?
-            @product_subscriptions = @issue.shipped_issues.map { |shipped_issue| shipped_issue.subscription }.compact
+            @product_subscriptions = Subscription.where(id: @issue.shipped_issues.pluck(:subscription_id))
           else
             @product_subscriptions = Subscription.eligible_for_shipping.where(:magazine_id => @magazine.id)
           end


### PR DESCRIPTION
We can use ActiveRecord here to avoid the n+1 queries problem where the earlier syntax would call all of the ShippedIssue objects one at a time from the db.  It also has the advantage of returning an ActiveRecord relation rather than an array, so it's extensible by other scopes, etc.
