### PR TITLE
Update Admin tab icon

### DIFF
--- a/app/overrides/subscriptions_admin_tab.rb
+++ b/app/overrides/subscriptions_admin_tab.rb
@@ -1,4 +1,4 @@
-Deface::Override.new(:virtual_path => "spree/admin/shared/_menu",
-                     :name => "subscriptions_admin_tab",
-                     :insert_bottom => "[data-hook='admin_tabs']",
-                     :text => "<%= tab(:subscriptions, :icon => 'icon-file') %>")
+Deface::Override.new(virtual_path: "spree/admin/shared/_menu",
+                     name: "subscriptions_admin_tab",
+                     insert_bottom: "[data-hook='admin_tabs']",
+                     text: "<%= tab :subscriptions, icon: 'calendar' %>")


### PR DESCRIPTION
This PR reinstates the icon on the Admin tab, following Spree 2.x syntax. Because the 'file' icon is currently being used by Spree's Reports page by default, I've used a calendar icon instead, which I think nicely works with the intuitive notion of a subscription.
