### PR TITLE
Spree 2.x styling for product dropdown

### DIFF
--- a/app/controllers/spree/admin/products/issues_controller.rb
+++ b/app/controllers/spree/admin/products/issues_controller.rb
@@ -72,7 +72,7 @@ module Spree
         end
 
         def load_products
-          @products = Product.unsubscribable.map { |product| [product.name, product.id] }
+          @products = Product.unsubscribable
         end
 
         def issue_params

--- a/app/views/spree/admin/products/issues/_form.html.erb
+++ b/app/views/spree/admin/products/issues/_form.html.erb
@@ -1,3 +1,11 @@
-<h3><%= t(:issue).titleize %></h3>
+<fieldset>
+  <%= f.field_container :name do %>
+    <%= f.label :name, "Issue Name (Optional)" %>
+    <%= f.text_field :name, class: 'fullwidth' %>
+  <% end %>
 
-<%= render 'issue_fields', :f => f %>  
+  <%= f.field_container :magazine_issue_id do %>
+    <%= f.label :magazine_issue_id, Spree.t(:product) %>
+    <%= f.collection_select(:magazine_issue_id, @products, :id, :name, { :include_blank => true }, { :class => 'select2 fullwidth' }) %>
+  <% end %>
+</fieldset>

--- a/app/views/spree/admin/products/issues/_issue_fields.html.erb
+++ b/app/views/spree/admin/products/issues/_issue_fields.html.erb
@@ -1,7 +1,0 @@
- <fieldset>
-  <%= f.label :name, t(:name, :scope => 'activerecord.attributes.spree/subscription') %>
-  <%= f.text_field :name %>
-
-  <%= f.label :magazine_issue_id, t(:product) %>
-  <%= f.select :magazine_issue_id, @products, :include_blank => true %>
-</fieldset>


### PR DESCRIPTION
This patch updates the New Issue view to Spree 2.x styling, which adds nice autocompletion to the product name and converts this view:

![screen shot 2014-08-04 at 3 45 33 pm](https://cloud.githubusercontent.com/assets/2460418/3804628/24142a9a-1c29-11e4-9917-a04ed97a9c09.png)

To this view:

![screen shot 2014-08-04 at 3 45 06 pm](https://cloud.githubusercontent.com/assets/2460418/3804629/27566844-1c29-11e4-84b5-9a34eb6da126.png)
