### PR TITLE
Use ActiveRecord includes to improve performance of PDF render

### DIFF
--- a/app/controllers/spree/admin/products/issues_controller.rb
+++ b/app/controllers/spree/admin/products/issues_controller.rb
@@ -15,9 +15,8 @@ module Spree
           respond_to do |format|
             format.html
             format.pdf do
-              addresses_list = @product_subscriptions.map { |s| s.ship_address }
-              labels = IssuePdf.new(addresses_list, view_context)
-              send_data labels.document.render, :filename => "#{@issue.name}.pdf", :type => "application/pdf", disposition: "inline"
+              labels = IssuePdf.new(Spree::Address.where(id: @product_subscriptions.pluck(:ship_address_id)).includes(:state, :country), view_context)
+              send_data labels.document.render, filename: "#{@issue.name}.pdf", type: "application/pdf", disposition: "inline"
             end
           end
         end


### PR DESCRIPTION
This PR uses ActiveRecord `includes` on state and country to significantly improve performance of PDF rendering in spree-subscriptions.
