### PR TITLE
fix n+1 queries on issues#show with includes(:ship_address)

### DIFF
--- a/app/controllers/spree/admin/products/issues_controller.rb
+++ b/app/controllers/spree/admin/products/issues_controller.rb
@@ -8,9 +8,9 @@ module Spree
 
         def show
           if @issue.shipped?
-            @product_subscriptions = Subscription.where(id: @issue.shipped_issues.pluck(:subscription_id))
+            @product_subscriptions = Subscription.where(id: @issue.shipped_issues.pluck(:subscription_id)).includes(:ship_address)
           else
-            @product_subscriptions = Subscription.eligible_for_shipping.where(:magazine_id => @magazine.id)
+            @product_subscriptions = @magazine.subscriptions.eligible_for_shipping.includes(:ship_address)
           end
           respond_to do |format|
             format.html


### PR DESCRIPTION
This patch speeds up the Issues#show action, saving us the n+1 queries slowdown of loading them one at a time in the view, by loading the `:ship_address` objects in a single batched query at the time we load the subscriptions.
