### PR TITLE
Fix typo in en.yml

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,7 +16,7 @@ en:
     issue: "issue"
     issue_created: "Issue created!"
     issue_not_created: "Issue not created!"
-    issue_not_shipped: "This issue has already been shipped"
+    issue_not_shipped: "Not yet shipped"
     issue_not_updated: "Issue not updated!"
     issue_shipped: "Issue successfully shipped"
     issue_updated: "Issue updated!"


### PR DESCRIPTION
This earlier PR was merged but then was accidentally overwritten with my later PR to namespace the Spree Il8ns. This brings the fix back!
