### PR TITLE
remove unused view file

### DIFF
--- a/app/views/spree/admin/products/issues/_issue_fields.html.erb
+++ b/app/views/spree/admin/products/issues/_issue_fields.html.erb
@@ -1,7 +1,0 @@
- <fieldset>
-  <%= f.label :name, Spree.t(:name, :scope => 'activerecord.attributes.spree/subscription') %>
-  <%= f.text_field :name %>
-
-  <%= f.label :magazine_issue_id, Spree.t(:product) %>
-  <%= f.select :magazine_issue_id, @products, :include_blank => true %>
-</fieldset>


### PR DESCRIPTION
The earlier commit https://github.com/nebulab/spree-subscriptions/commit/0b12cc727c4972399ed87b030fe57bf19036329c made it so that we are no longer using this view file, and it can now be safely removed.
