### PR TITLE
subscription model now has issues through shipped_issues

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -2,6 +2,7 @@ class Spree::Subscription < ActiveRecord::Base
   belongs_to :magazine, :class_name => 'Spree::Product'
   belongs_to :ship_address, :class_name => 'Spree::Address'
   has_many :shipped_issues
+  has_many :issues, through: :shipped_issues
 
   alias_method :shipping_address, :ship_address
   alias_method :shipping_address=, :ship_address=


### PR DESCRIPTION
In a similar vein to https://github.com/nebulab/spree-subscriptions/pull/36, I find it very convenient to be able to write `subscription.issues` rather than something like `Spree::Issue.where(id: subscription.shipped_issues.pluck(:issue_id))` or `subscription.shipped_issues.collect {|shipped_issue| shipped_issue.issue}`. Seems like it'd be useful to other folks as well.
