### PR TITLE
add counter_cache for performance improvements on # of shipped issues

### DIFF
--- a/app/models/spree/shipped_issue.rb
+++ b/app/models/spree/shipped_issue.rb
@@ -1,5 +1,5 @@
 class Spree::ShippedIssue < ActiveRecord::Base
-  belongs_to :issue, autosave: true
+  belongs_to :issue, autosave: true, counter_cache: true
   belongs_to :subscription, autosave: true
   has_one :magazine_issue, through: :issue
 end

--- a/db/migrate/20140829210700_add_shipped_issue_counter_cache_column.rb
+++ b/db/migrate/20140829210700_add_shipped_issue_counter_cache_column.rb
@@ -1,0 +1,14 @@
+class AddShippedIssueCounterCacheColumn < ActiveRecord::Migration
+  def up
+    add_column :spree_issues, :shipped_issues_count, :integer, default: 0
+
+    Spree::Issue.reset_column_information
+    Spree::Issue.all.each do |issue|
+      Spree::Issue.reset_counters issue.id, :shipped_issues
+    end
+  end
+
+  def down
+    remove_column :spree_issues, :shipped_issues_count
+  end
+end


### PR DESCRIPTION
This migration adds a counter cache column to `Spree::Issues` to track `shipped_issues.size`. Doing this will result in many fewer trips to the db and performance improvements on backend view pages such as Product/issues/index.
