### PR TITLE
Remove duplicate unship method

### DIFF
--- a/app/controllers/spree/admin/products/issues_controller.rb
+++ b/app/controllers/spree/admin/products/issues_controller.rb
@@ -82,16 +82,6 @@ module Spree
           redirect_to admin_magazine_issues_path(@magazine)
         end
 
-        def unship
-          if @issue.shipped?
-            @issue.unship!
-            flash[:notice]  = Spree.t('issue_unshipped')
-          else
-            flash[:error]  = Spree.t('issue_not_shipped')
-          end
-          redirect_to admin_magazine_issues_path(@magazine)
-        end
-
         private
 
         def load_magazine


### PR DESCRIPTION
For some reason the way the last two PRs were merged caused git to add this method twice. We can safely remove the second one.
